### PR TITLE
Update deploy workflow to transpile using Babel

### DIFF
--- a/.github/workflows/deploy_sam_app.yml
+++ b/.github/workflows/deploy_sam_app.yml
@@ -22,12 +22,11 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
 
-      - name: Yarn install and build
+      - name: Yarn Install and Build
         run: |
           cd functions
           yarn install
           yarn build
-          cd ..
 
       - name: Configure Variables
         id: vars

--- a/.github/workflows/deploy_sam_app.yml
+++ b/.github/workflows/deploy_sam_app.yml
@@ -2,6 +2,10 @@ name: deploy_sam_app
 
 on:
   workflow_call:
+    inputs:
+      node:
+        required: false
+        type: boolean
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -23,6 +27,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Yarn Install and Build
+        if: ${{ inputs.node == true }}
         run: |
           cd functions
           yarn install

--- a/.github/workflows/deploy_sam_app.yml
+++ b/.github/workflows/deploy_sam_app.yml
@@ -27,9 +27,7 @@ jobs:
           cd functions
           yarn install
           yarn build
-          ls
           cd ..
-          ls
 
       - name: Configure Variables
         id: vars

--- a/.github/workflows/deploy_sam_app.yml
+++ b/.github/workflows/deploy_sam_app.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           cd functions
           yarn install
+          yarn build
           ls
           cd ..
           ls

--- a/.github/workflows/deploy_sam_app.yml
+++ b/.github/workflows/deploy_sam_app.yml
@@ -22,6 +22,15 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
 
+      - name: Yarn install and build
+        run: |
+          cd functions
+          yarn install
+          yarn build
+          ls
+          cd ..
+          ls
+
       - name: Configure Variables
         id: vars
         env:

--- a/.github/workflows/deploy_sam_app.yml
+++ b/.github/workflows/deploy_sam_app.yml
@@ -26,7 +26,6 @@ jobs:
         run: |
           cd functions
           yarn install
-          yarn build
           ls
           cd ..
           ls


### PR DESCRIPTION
Added a step in the deploy workflow to run two `yarn` commands:

`yarn install` - to install dependencies
`yarn build` - which will be defined in each `package.json` to transpile via babel

the `yarn install` is needed so that the `yarn build`, which looks for `babel` in the `node_modules`, will work.

`yarn build` results in the transpiled src files being written to a `/dist` directory. when `sam build` runs, it calls `npm install`, which will install dependencies and the contents of the `\dist` directory to the `.aws-sam` folder