### PR TITLE
Bump versions for actions.

### DIFF
--- a/.github/workflows/bump_node_app_version.yml
+++ b/.github/workflows/bump_node_app_version.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_BUILD_TOKEN }}
 
       - name: Bump Version and Tag
-        uses: TriPSs/conventional-changelog-action@v3
+        uses: TriPSs/conventional-changelog-action@v4
         with:
           github-token: ${{ secrets.GITHUB_BUILD_TOKEN }}
           release-count: 0

--- a/.github/workflows/check_semantic_pr.yml
+++ b/.github/workflows/check_semantic_pr.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for Semantic PR
-        uses: amannn/action-semantic-pull-request@v3.4.2
+        uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_BUILD_TOKEN }}

--- a/.github/workflows/delete_sam_app.yml
+++ b/.github/workflows/delete_sam_app.yml
@@ -34,7 +34,7 @@ jobs:
           echo "GITHUB_RUN_NUMBER=$GITHUB_RUN_NUMBER"
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy_sam_app.yml
+++ b/.github/workflows/deploy_sam_app.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Yarn Install and Build
         if: ${{ inputs.node == true }}
@@ -48,7 +48,7 @@ jobs:
           echo "GITHUB_RUN_NUMBER=$GITHUB_RUN_NUMBER"
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Yarn Install
         run: yarn install

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Yarn Install
         run: yarn install


### PR DESCRIPTION
Noticed when some of the sam actions were running that we were getting this error: 
<img width="1360" alt="image" src="https://github.com/runslikebutter/sam-workflows/assets/4857700/718ba5ef-614e-452b-a827-561ce2484a7e">

Github has deprecated the use of actions that run on Node12: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

Most actions have updated to run on Node16+. This PR updates the versions of the actions used in this repo to the most current versions. I did some sanity check testing to make sure things are okay:

- Successful deploy: https://github.com/runslikebutter/smart-home-thermostats-sam/actions/runs/6476594171
- Created a PR to `main` to check that the semantic PR check works: https://github.com/runslikebutter/smart-home-thermostats-sam/pull/4

The only thing I haven't tested is the `bump_node_app_version` workflow, since that requires merging into `main`. I feel fairly confident it'll be okay, but can leave it out if that's what you prefer.